### PR TITLE
test: add Playwright coverage for existing UI features

### DIFF
--- a/tests/derivation.spec.ts
+++ b/tests/derivation.spec.ts
@@ -1,0 +1,34 @@
+import { expect, test } from "@playwright/test";
+
+const mnemonic =
+  "message mask aunt wheel ten maze between tomato slow analyst ladder such report capital produce";
+const firstAddressPublicKey =
+  "addr_xvk1gs3fqwhyayz2drdx857yw7jyvnjqsje2sc7qlx4ryp8z4cpvh4hn4tnjeqqtultplcgwp067389dy5fafmnqtreus6tju0ueyrjnynq0l3lh3";
+const secondAddressPublicKey =
+  "addr_xvk1lz7rn3xtrxuk9gn38gzpd9rjpknlu9758z70hkl9wu79hc7xqw7fxu57u5r4xcyjrxl7q0j9533zv2mnsqhzmkpxw50lqmcdn7f5m7s943403";
+
+test("derivation page is reactive and hides values in private mode", async ({
+  page,
+}) => {
+  await page.goto("/");
+
+  await page.getByRole("button", { name: /Derivation Follow CIP-1852/ }).click();
+  await expect(page.getByRole("heading", { name: "Key Derivation" })).toBeVisible();
+
+  const mnemonicInput = page.locator(
+    'input[type="password"][placeholder="abandon abandon ... or use the generated phrase"]',
+  );
+  await mnemonicInput.fill(mnemonic);
+
+  await expect(
+    page.getByText("Value hidden in private mode. Use Copy to move it to the clipboard.").first(),
+  ).toBeVisible();
+  await expect(page.getByText(firstAddressPublicKey)).toHaveCount(0);
+
+  await page.getByRole("button", { name: "Visible" }).click();
+  await expect(page.getByText(firstAddressPublicKey)).toBeVisible();
+
+  await page.getByRole("spinbutton", { name: "Address index" }).fill("1");
+  await expect(page.getByText(secondAddressPublicKey)).toBeVisible();
+  await expect(page.getByText(firstAddressPublicKey)).toHaveCount(0);
+});

--- a/tests/inspect.spec.ts
+++ b/tests/inspect.spec.ts
@@ -1,0 +1,27 @@
+import { expect, test } from "@playwright/test";
+
+const shelleyAddress =
+  "addr1vyeq0sedsphv9j4u0rlhakrfh5cf3d7mj0zrej92jw44n6c0fpycd";
+
+test("inspect page decodes a Shelley address", async ({ page }) => {
+  await page.goto("/");
+
+  await page.getByRole("button", { name: /Inspect Decode addresses/ }).click();
+  await expect(page.locator(".page-title")).toHaveText("Address Inspection");
+
+  await expect(
+    page.getByText(
+      "No address inspected yet. Supported today: Shelley bech32 plus Byron and Icarus base58 inspection.",
+    ),
+  ).toBeVisible();
+
+  await page.getByPlaceholder("addr1... or DdzFF...").fill(shelleyAddress);
+  await page.getByRole("button", { name: "Inspect address" }).click();
+
+  await expect(page.getByText("Shelley")).toBeVisible();
+  await expect(page.getByText("Enterprise address (key)")).toBeVisible();
+  await expect(page.getByText("Mainnet")).toBeVisible();
+  await expect(
+    page.getByText("3207c32d806ec2cabc78ff7ed869bd3098b7db93c43cc8aa93ab59eb"),
+  ).toBeVisible();
+});

--- a/tests/mnemonic.spec.ts
+++ b/tests/mnemonic.spec.ts
@@ -1,0 +1,20 @@
+import { expect, test } from "@playwright/test";
+
+test("mnemonic page respects privacy mode", async ({ page }) => {
+  await page.goto("/");
+
+  await page.getByRole("button", { name: /Mnemonic Generate recovery phrases/ }).click();
+  await expect(page.locator(".page-title")).toHaveText("Mnemonic Generation");
+
+  await page.getByRole("button", { name: "12 words" }).click();
+  await page.getByRole("button", { name: "Generate phrase" }).click();
+
+  await expect(page.getByRole("button", { name: "Copy phrase" })).toBeVisible();
+  await expect(
+    page.getByText("Phrase hidden. 12 words are available for clipboard copy."),
+  ).toBeVisible();
+  await expect(page.locator(".mnemonic-word")).toHaveCount(0);
+
+  await page.getByRole("button", { name: "Visible" }).click();
+  await expect(page.locator(".mnemonic-word")).toHaveCount(12);
+});

--- a/tests/scripts.spec.ts
+++ b/tests/scripts.spec.ts
@@ -1,0 +1,20 @@
+import { expect, test } from "@playwright/test";
+
+const scriptCborHex =
+  "008200581c3207c32d806ec2cabc78ff7ed869bd3098b7db93c43cc8aa93ab59eb";
+const scriptHashHex =
+  "558ba956d2a19cecd37cb49d3f0ddff1985013dd86e695128bc3d996";
+const scriptHashBech32 =
+  "script12k96j4kj5xwwe5mukjwn7rwl7xv9qy7asmnf2y5tc0vevku89av";
+
+test("scripts page hashes native script CBOR", async ({ page }) => {
+  await page.goto("/");
+
+  await page.getByRole("button", { name: /Scripts Hash native scripts/ }).click();
+  await expect(page.getByRole("heading", { name: "Native Scripts" })).toBeVisible();
+
+  await page.getByPlaceholder("8200581c...").fill(scriptCborHex);
+
+  await expect(page.getByText(scriptHashHex)).toBeVisible();
+  await expect(page.getByText(scriptHashBech32)).toBeVisible();
+});


### PR DESCRIPTION
Closes #14

## Summary
- add Playwright coverage for the existing Inspect, Mnemonic, Derivation, and Scripts panels
- keep the legacy bootstrap coverage already in place and extend the suite to cover privacy-sensitive behavior
- assert against fixture-backed browser outputs instead of layout details

## Verification
- nix run .#ci-playwright