### PR TITLE
fix: ship WASM asset in GitHub Pages web-dist

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -213,11 +213,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1775882010,
+        "lastModified": 1776072124,
         "narHash": "sha256-ZTD/BHZBzJXvVSByGDbNGxhksqclAS0R5MW7N+TiLMc=",
         "owner": "paolino",
         "repo": "cardano-addresses",
-        "rev": "55a30aaa6ad397d131b105faca7a5e2672f9b1bc",
+        "rev": "7a4f2b572e1aaa735cbcf93e3070f3beeda48b0f",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -49,7 +49,7 @@
           '';
           testVectorsPath = test-vectors-json;
           purescript = import ./nix/purescript.nix {
-            inherit pkgs repoRoot;
+            inherit pkgs repoRoot wasmBinary;
           };
           packages = import ./nix/packages {
             inherit pkgs repoRoot purescript haskellProject playwrightBrowsers testVectorsPath;

--- a/nix/purescript.nix
+++ b/nix/purescript.nix
@@ -1,4 +1,4 @@
-{ pkgs, repoRoot }:
+{ pkgs, repoRoot, wasmBinary }:
 
 let
   nodejs = pkgs.nodejs_22;
@@ -134,9 +134,10 @@ in
       cd ..
     '';
     installPhase = ''
-      mkdir -p $out
+      mkdir -p $out/wasm
       cp ${repoRoot}/dist/index.html $out/index.html
       cp dist/app.js $out/
+      cp ${wasmBinary}/cardano-addresses.wasm $out/wasm/cardano-addresses.wasm
     '';
   };
 }


### PR DESCRIPTION
## Summary
GitHub Pages is currently publishing a broken app build because `web-dist` only installs `index.html` and `app.js`, while the browser app fetches `wasm/cardano-addresses.wasm` at runtime.

This PR fixes the packaging so the Pages artifact includes the WASM binary and updates the locked `cardano-addresses` input to the rebased `001-wasm-target` commit.

## What Changed
- pass `wasmBinary` into `nix/purescript.nix`
- include `wasm/cardano-addresses.wasm` in the `web-dist` install phase
- refresh the `cardano-addresses` flake lock from `55a30aaa6ad397d131b105faca7a5e2672f9b1bc` to `7a4f2b572e1aaa735cbcf93e3070f3beeda48b0f`

## Why
The deployed site at `https://lambdasistemi.github.io/cardano-addresses-browser/` currently fails in the Inspect panel with:
- `Failed to fetch WASM: HTTP 404`
- missing asset: `https://lambdasistemi.github.io/cardano-addresses-browser/wasm/cardano-addresses.wasm`

The repo's Playwright check already expected that layout, but the Pages workflow uploads `.#web-dist`, and `web-dist` was not copying the WASM file.

## Verification
- built the actual Pages artifact locally with `nix build .#web-dist`
- confirmed the built artifact contains `result-dist/wasm/cardano-addresses.wasm`
- published the fixed real app artifact to Surge: https://cardano-addresses-browser-real-202604131006.surge.sh
- verified the Inspect panel on that preview decodes `addr1vw83dnlqqtdrlct4kz3f7d07d59w6p4yrtlr62340yklhaqcxeph4` successfully
- verified the current GitHub Pages deployment is broken for the same action: https://lambdasistemi.github.io/cardano-addresses-browser/

## Reviewer Notes
The behavioral change is limited to deployment packaging and the pinned upstream WASM commit. The browser app code path was already correct; GitHub Pages just was not shipping the runtime binary it needed.
