### PR TITLE
chore: sunset in favor of cardano-swiss-knife

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # cardano-addresses-browser
 
+> **Superseded by [cardano-swiss-knife](https://github.com/lambdasistemi/cardano-swiss-knife).** That repo is a strict superset of this one (same app shell, same features) plus vault-backed transaction signing and witness attachment. This repo is no longer actively developed; the GitHub Pages site stays up as-is. Open backlog issues have moved to `cardano-swiss-knife`.
+
 Browser-based Cardano address toolkit. Mnemonic generation, key derivation, address construction, inspection, signing — all running client-side with no backend.
 
 ## Architecture

--- a/app/src/Main.purs
+++ b/app/src/Main.purs
@@ -3,11 +3,15 @@ module Main where
 import Prelude
 
 import App as App
+import Data.Maybe (maybe)
 import Effect (Effect)
 import Halogen.Aff as HA
 import Halogen.VDom.Driver (runUI)
+import Web.DOM.ParentNode (QuerySelector(..))
 
 main :: Effect Unit
 main = HA.runHalogenAff do
-  body <- HA.awaitBody
-  runUI App.component unit body
+  HA.awaitLoad
+  mRoot <- HA.selectElement (QuerySelector "#app-root")
+  root <- maybe HA.awaitBody pure mRoot
+  runUI App.component unit root

--- a/dist/index.html
+++ b/dist/index.html
@@ -607,6 +607,31 @@
     </style>
   </head>
   <body>
+    <div
+      style="
+        position: sticky;
+        top: 0;
+        z-index: 1000;
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.5em 1em;
+        align-items: center;
+        justify-content: center;
+        padding: 0.6em 1em;
+        background: var(--accent-soft);
+        border-bottom: 1px solid var(--border);
+        color: var(--text);
+        font-size: 0.9em;
+        text-align: center;
+      "
+    >
+      <span>
+        This project is superseded by
+        <a href="https://lambdasistemi.github.io/cardano-swiss-knife/" style="color: var(--accent); font-weight: 600;">cardano-swiss-knife</a>,
+        which includes everything here plus transaction signing and witness attachment. This page stays up, but new work happens there.
+      </span>
+    </div>
+    <div id="app-root"></div>
     <script>
       globalThis.global = globalThis;
       globalThis.process = globalThis.process ?? { env: {}, browser: true };


### PR DESCRIPTION
## Summary

- Verified cardano-swiss-knife is a strict superset of this repo: identical Page/Action constructors, identical file set plus `TxInspector/Signing.{purs,js}`, and every shared file's diff is additive or an improvement (no removed functionality).
- Adds a sticky deprecation banner to the live page linking to cardano-swiss-knife.
- Mount point moves from raw `body` to `#app-root` so the banner survives Halogen's render (falls back to `awaitBody` if `#app-root` is absent).
- README gets a top-of-file notice.

Site stays live and functional as-is; no further feature work is planned here.

## Test plan

- [x] `nix develop -c npx spago build -p cardano-addresses-browser` — 0 warnings, 0 errors
- [ ] Visual check of the banner on a built preview (Pages preview deploy will build via `nix build .#web-dist`)